### PR TITLE
up

### DIFF
--- a/.github/workflows/publish-oci.yml
+++ b/.github/workflows/publish-oci.yml
@@ -4,12 +4,10 @@ on:
   push:
     branches:
       - main
-    tags:
-      - "v*"
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   packages: write
 
 jobs:
@@ -20,11 +18,32 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Set up Helm
         uses: azure/setup-helm@v4
         with:
           version: v3.17.3
+
+      # ── Auto-versioning ────────────────────────────────────────────────────
+      - name: Calculate version
+        id: version
+        uses: paulhatch/semantic-version@v6.0.2
+        with:
+          tag_prefix: "v"
+          major_pattern: "(MAJOR)"
+          minor_pattern: "(MINOR)"
+          version_format: "${major}.${minor}.${patch}"
+          bump_each_commit: false
+          search_commit_body: false
+
+      - name: Set NEXT_VERSION
+        run: echo "NEXT_VERSION=${{ steps.version.outputs.version }}" >> $GITHUB_ENV
+
+      - name: Print version
+        run: echo "Publishing version ${{ env.NEXT_VERSION }}"
 
       - name: Log in to GitHub Container Registry
         run: |
@@ -36,13 +55,11 @@ jobs:
       - name: Package drunk-lib
         working-directory: drunk-lib
         run: |
-          VERSION=$(grep '^version:' Chart.yaml | awk '{print $2}')
-          echo "DRUNK_LIB_VERSION=${VERSION}" >> "$GITHUB_ENV"
-          helm package . --destination /tmp/charts
+          helm package . --version ${{ env.NEXT_VERSION }} --destination /tmp/charts
 
       - name: Push drunk-lib to GHCR
         run: |
-          helm push /tmp/charts/drunk-lib-${{ env.DRUNK_LIB_VERSION }}.tgz \
+          helm push /tmp/charts/drunk-lib-${{ env.NEXT_VERSION }}.tgz \
             oci://ghcr.io/${{ github.repository_owner }}
 
       # ── drunk-app ──────────────────────────────────────────────────────────
@@ -56,15 +73,26 @@ jobs:
       - name: Package drunk-app
         working-directory: drunk-app
         run: |
-          VERSION=$(grep '^version:' Chart.yaml | awk '{print $2}')
-          echo "DRUNK_APP_VERSION=${VERSION}" >> "$GITHUB_ENV"
-          helm package . --destination /tmp/charts
+          helm package . --version ${{ env.NEXT_VERSION }} --destination /tmp/charts
 
       - name: Push drunk-app to GHCR
         run: |
-          helm push /tmp/charts/drunk-app-${{ env.DRUNK_APP_VERSION }}.tgz \
+          helm push /tmp/charts/drunk-app-${{ env.NEXT_VERSION }}.tgz \
             oci://ghcr.io/${{ github.repository_owner }}
 
       - name: Log out from GHCR
         if: always()
         run: helm registry logout ghcr.io
+
+      # ── GitHub Release ─────────────────────────────────────────────────────
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2.6.1
+        with:
+          generate_release_notes: true
+          make_latest: true
+          tag_name: v${{ env.NEXT_VERSION }}
+          name: Release v${{ env.NEXT_VERSION }}
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-oci.yml
+++ b/.github/workflows/publish-oci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v4
         with:
-          version: latest
+          version: v3.17.3
 
       - name: Log in to GitHub Container Registry
         run: |
@@ -49,8 +49,9 @@ jobs:
       - name: Resolve drunk-app dependencies
         working-directory: drunk-app
         run: |
-          # Point dependency to the local drunk-lib instead of a remote repo
-          helm dependency update .
+          # Chart.yaml already uses repository: "file://../drunk-lib"
+          # helm dependency build resolves local file:// dependencies without network access
+          helm dependency build .
 
       - name: Package drunk-app
         working-directory: drunk-app

--- a/.github/workflows/publish-oci.yml
+++ b/.github/workflows/publish-oci.yml
@@ -1,0 +1,69 @@
+name: Publish Helm Charts as OCI
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: Build and Publish Helm Charts to GHCR
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: latest
+
+      - name: Log in to GitHub Container Registry
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io \
+            --username ${{ github.actor }} \
+            --password-stdin
+
+      # ── drunk-lib ──────────────────────────────────────────────────────────
+      - name: Package drunk-lib
+        working-directory: drunk-lib
+        run: |
+          VERSION=$(grep '^version:' Chart.yaml | awk '{print $2}')
+          echo "DRUNK_LIB_VERSION=${VERSION}" >> "$GITHUB_ENV"
+          helm package . --destination /tmp/charts
+
+      - name: Push drunk-lib to GHCR
+        run: |
+          helm push /tmp/charts/drunk-lib-${{ env.DRUNK_LIB_VERSION }}.tgz \
+            oci://ghcr.io/${{ github.repository_owner }}
+
+      # ── drunk-app ──────────────────────────────────────────────────────────
+      - name: Resolve drunk-app dependencies
+        working-directory: drunk-app
+        run: |
+          # Point dependency to the local drunk-lib instead of a remote repo
+          helm dependency update .
+
+      - name: Package drunk-app
+        working-directory: drunk-app
+        run: |
+          VERSION=$(grep '^version:' Chart.yaml | awk '{print $2}')
+          echo "DRUNK_APP_VERSION=${VERSION}" >> "$GITHUB_ENV"
+          helm package . --destination /tmp/charts
+
+      - name: Push drunk-app to GHCR
+        run: |
+          helm push /tmp/charts/drunk-app-${{ env.DRUNK_APP_VERSION }}.tgz \
+            oci://ghcr.io/${{ github.repository_owner }}
+
+      - name: Log out from GHCR
+        if: always()
+        run: helm registry logout ghcr.io


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the building, versioning, packaging, and publishing of Helm charts as OCI images to the GitHub Container Registry (GHCR), as well as creating a corresponding GitHub Release. This streamlines the release process for both the `drunk-lib` and `drunk-app` charts.

Key additions in the workflow:

**Helm Chart Publishing Automation:**
* Adds `.github/workflows/publish-oci.yml` to automate the build and publish process for Helm charts to GHCR, including both `drunk-lib` and `drunk-app` charts.

**Versioning and Release Management:**
* Implements semantic versioning using the `paulhatch/semantic-version` action to automatically determine the next chart version.
* Automatically creates a GitHub Release with release notes for each published version.

**Dependency Management:**
* Resolves local dependencies for `drunk-app` on `drunk-lib` before packaging, ensuring correct chart builds.