### PR TITLE
up

### DIFF
--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -80,36 +80,20 @@ jobs:
             node -e "const fs=require('fs');const j=JSON.parse(fs.readFileSync('$f','utf8'));j.version=process.env.NEXT_VERSION;fs.writeFileSync('$f',JSON.stringify(j,null,2)+'\n');"
           done
 
-      - name: Commit version bump
+      - name: Check if version already published
         id: commit_bump
         if: steps.flag.outputs.enable == 'true'
         env:
           NEXT_VERSION: ${{ env.NEXT_VERSION }}
         run: |
           set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-          git add package.json .claude-plugin/marketplace.json plugins/*/.claude-plugin/plugin.json
-
-          if git diff --cached --quiet; then
-            echo "No version diff to commit"
+          if npm view "@drunkcoding/drunk-charts@${NEXT_VERSION}" version >/dev/null 2>&1; then
+            echo "Version ${NEXT_VERSION} already published to npm, skipping"
             echo "changed=false" >> "$GITHUB_OUTPUT"
-            exit 0
+          else
+            echo "Version ${NEXT_VERSION} not yet published"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
-
-          git commit -m "chore(release): npm v${NEXT_VERSION} [skip ci]"
-          echo "changed=true" >> "$GITHUB_OUTPUT"
-
-          # Tolerate concurrent push from publish-oci.yml on the same SHA.
-          for i in 1 2 3; do
-            if git push origin HEAD:main; then
-              exit 0
-            fi
-            git pull --rebase origin main
-          done
-          echo "::error::Failed to push version bump after 3 rebase attempts"
-          exit 1
 
       - name: Publish to npm
         if: steps.flag.outputs.enable == 'true' && steps.commit_bump.outputs.changed == 'true'


### PR DESCRIPTION
This pull request updates the npm publish workflow to prevent publishing a package version that has already been published. Instead of always committing and pushing a version bump, the workflow now checks if the version exists on npm and skips the commit and push if it does.

**Workflow improvements:**

* The workflow now checks if the intended `NEXT_VERSION` is already published on npm before proceeding with the commit and push steps, preventing duplicate version publishing.
* The previous logic for committing and pushing version bumps has been removed, including retries for concurrent pushes, simplifying the workflow and reducing possible errors.